### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-01-23
+
+This is purely an administrative release -- no code changes
+
 ## [0.1.0] - 2022-01-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtn-gimbal-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gimbal SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
No code changes.  We can't republish tag 0.1.0 after a publishing mistake.